### PR TITLE
Update licensing information, add ThirdParty.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright 2017-2022 CesiumGS Contributors
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -199,3 +201,32 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+# Third-Party Code
+
+strip-pragma-loader includes the following third-party code.
+
+### loader-utils
+
+https://github.com/webpack/loader-utils
+
+> Copyright JS Foundation and other contributors
+>
+> Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+>
+> The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -1,0 +1,8 @@
+[
+    {
+        "name": "loader-utils",
+        "license": ["MIT"],
+        "version": "1.4.0",
+        "url": "https://github.com/webpack/loader-utils"
+    }
+]


### PR DESCRIPTION
This updates the license file with the copyright information and the direct dependencies.

This also adds `ThirdParty.json` to be consistant with [how CesiumJS and other Cesium repos document third-party dependencies](https://github.com/CesiumGS/cesium/pull/10295).

@sanjeetsuhag Could you review this after https://github.com/CesiumGS/cesium/pull/10295?