### PR TITLE
Update loader-utils package because of security vulnerability fix

### DIFF
--- a/ThirdParty.json
+++ b/ThirdParty.json
@@ -2,7 +2,7 @@
     {
         "name": "loader-utils",
         "license": ["MIT"],
-        "version": "1.4.0",
+        "version": "1.4.1",
         "url": "https://github.com/webpack/loader-utils"
     }
 ]

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "webpack": "2.x || 3.x || 4.x || 5.x"
   },
   "dependencies": {
-    "loader-utils": "^1.1.0"
+    "loader-utils": "^1.4.1"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/strip-pragma-loader/issues/7 by updating the `loader-utils` to [1.4.1](https://github.com/webpack/loader-utils/releases/tag/v1.4.1) which fixes a security vulnerability. 

Once merged, we can create a patch release for this package on npm.