### PR TITLE
Fix webpack config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In your webpack configuration object, you'll need to add `strip-pragma-loader` t
 module: {
 	rules: [{
 		test: /\.js$/,
-		enforce: pre,
+		enforce: 'pre',
 		use: [{
 			loader: 'strip-pragma-loader',
 			options: {
@@ -53,7 +53,7 @@ For example, the following would strip out all blocks beginning with `//>>includ
 module: {
 	rules: [{
 		test: /\.js$/,
-		enforce: pre,
+		enforce: 'pre',
 		use: [{
 			loader: 'strip-pragma-loader',
 			options: {


### PR DESCRIPTION
Fixes #5

The docs for [`Rules.enforce`](https://webpack.js.org/configuration/module/#ruleenforce) specify the value as a string of `'pre' | 'post'` meaning just copying from our docs it's not a working config